### PR TITLE
Use correct column name when checking configuration uniqueness

### DIFF
--- a/cloud_functions/big_query.py
+++ b/cloud_functions/big_query.py
@@ -200,11 +200,14 @@ class BigQueryDataset:
         # Installation data is stored in a separate column, so pop it before the next step.
         installation_data = configuration.pop("installation_data")
 
-        configuration_json = json.dumps(configuration)
-        configuration_hash = blake3(configuration_json.encode()).hexdigest()
+        software_configuration_json = json.dumps(configuration)
+        software_configuration_hash = blake3(software_configuration_json.encode()).hexdigest()
 
         configurations = list(
-            self.client.query(f"SELECT id FROM `{table_name}` WHERE `hash`='{configuration_hash}' LIMIT 1").result()
+            self.client.query(
+                f"SELECT id FROM `{table_name}` WHERE `software_configuration_hash`='{software_configuration_hash}' "
+                f"LIMIT 1"
+            ).result()
         )
 
         if len(configurations) > 0:
@@ -222,8 +225,8 @@ class BigQueryDataset:
             rows=[
                 {
                     "id": configuration_id,
-                    "software_configuration": configuration_json,
-                    "software_configuration_hash": configuration_hash,
+                    "software_configuration": software_configuration_json,
+                    "software_configuration_hash": software_configuration_hash,
                     "installation_data": installation_data_json,
                     "installation_data_hash": installation_data_hash,
                 }

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("LICENSE") as f:
 
 setup(
     name="data_gateway",
-    version="0.7.4",
+    version="0.7.5",
     install_requires=[
         "click>=7.1.2",
         "pyserial==3.5",


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents ([#11](https://github.com/aerosense-ai/data-gateway/pull/11))

### Fixes
- Use correct column name when checking configuration uniqueness

<!--- END AUTOGENERATED NOTES --->