### PR TITLE
Add ability to provide sensor command routines

### DIFF
--- a/data_gateway/cli.py
+++ b/data_gateway/cli.py
@@ -185,7 +185,7 @@ def start(
         else:
             if os.path.exists(routine_file):
                 with open(routine_file) as f:
-                    routine = Routine(**json.load(f))
+                    routine = Routine(**json.load(f), action=lambda command: serial_port.write(command.encode("utf_8")))
                 logger.info("Loaded routine file from %r.", routine_file)
             else:
                 routine = None
@@ -261,7 +261,6 @@ def start(
 
         else:
             if routine is not None:
-                routine.action = lambda command: serial_port.write(command.encode("utf_8"))
                 routine.run()
 
     except KeyboardInterrupt:

--- a/data_gateway/cli.py
+++ b/data_gateway/cli.py
@@ -12,7 +12,7 @@ from slugify import slugify
 
 from data_gateway.configuration import Configuration
 from data_gateway.dummy_serial import DummySerial
-from data_gateway.exceptions import WrongNumberOfSensorCoordinatesError
+from data_gateway.exceptions import DataMustBeSavedError, WrongNumberOfSensorCoordinatesError
 from data_gateway.routine import Routine
 
 
@@ -165,6 +165,12 @@ def start(
     import threading
 
     from data_gateway.packet_reader import PacketReader
+
+    if not save_locally and no_upload_to_cloud:
+        raise DataMustBeSavedError(
+            "Data from the gateway must either be saved locally or uploaded to the cloud. Please adjust the CLI "
+            "options provided."
+        )
 
     config = _load_configuration(configuration_path=config_file)
     config.session_data["label"] = label

--- a/data_gateway/cli.py
+++ b/data_gateway/cli.py
@@ -382,6 +382,7 @@ def _load_routine(routine_path, interactive, serial_port):
     if os.path.exists(routine_path):
         if interactive:
             logger.warning("Sensor command routine files are ignored in interactive mode.")
+            return
         else:
             with open(routine_path) as f:
                 routine = Routine(
@@ -396,8 +397,6 @@ def _load_routine(routine_path, interactive, serial_port):
         "No routine file found at %r - no commands will be sent to the sensors unless given in interactive mode.",
         routine_path,
     )
-
-    return None
 
 
 def _update_and_create_output_directory(output_directory_path):

--- a/data_gateway/cli.py
+++ b/data_gateway/cli.py
@@ -71,11 +71,7 @@ def gateway_cli(logger_uri, log_level):
     help="Path to sensor command routine JSON file.",
 )
 @click.option(
-    "--save-locally",
-    "-l",
-    is_flag=True,
-    default=False,
-    show_default=True,
+    "--save-locally", "-l", is_flag=True, default=False, show_default=True, help="Save output JSON data to disk."
 )
 @click.option(
     "--no-upload-to-cloud",
@@ -83,6 +79,7 @@ def gateway_cli(logger_uri, log_level):
     is_flag=True,
     default=False,
     show_default=True,
+    help="Don't upload output JSON data to the cloud.",
 )
 @click.option(
     "--interactive",

--- a/data_gateway/cli.py
+++ b/data_gateway/cli.py
@@ -209,8 +209,8 @@ def start(
 
     # Start a new thread to parse the serial data while the main thread stays ready to take in commands from stdin.
     packet_reader = PacketReader(
-        save_locally=True,
-        upload_to_cloud=False,
+        save_locally=save_locally,
+        upload_to_cloud=not no_upload_to_cloud,
         output_directory=output_dir,
         window_size=window_size,
         project_name=gcp_project_name,

--- a/data_gateway/cli.py
+++ b/data_gateway/cli.py
@@ -400,9 +400,7 @@ def _update_and_create_output_directory(output_directory_path):
     if not output_directory_path.startswith("/"):
         output_directory_path = os.path.join(".", output_directory_path)
 
-    if not os.path.exists(output_directory_path):
-        os.makedirs(output_directory_path)
-
+    os.makedirs(output_directory_path, exist_ok=True)
     return output_directory_path
 
 

--- a/data_gateway/cli.py
+++ b/data_gateway/cli.py
@@ -371,7 +371,8 @@ def _get_serial_port(serial_port, configuration, use_dummy_serial_port):
 
 def _load_routine(routine_path, interactive, serial_port):
     """Load a sensor commands routine from the path if exists, otherwise return no routine. If in interactive mode, the
-    routine file is ignored.
+    routine file is ignored. Note that "\n" has to be added to the end of each command sent to the serial port for it to
+    be executed - this is done automatically in this method.
 
     :param str routine_path:
     :param bool interactive:
@@ -383,7 +384,10 @@ def _load_routine(routine_path, interactive, serial_port):
             logger.warning("Sensor command routine files are ignored in interactive mode.")
         else:
             with open(routine_path) as f:
-                routine = Routine(**json.load(f), action=lambda command: serial_port.write(command.encode("utf_8")))
+                routine = Routine(
+                    **json.load(f),
+                    action=lambda command: serial_port.write((command + "\n").encode("utf_8")),
+                )
 
             logger.info("Loaded routine file from %r.", routine_path)
             return routine

--- a/data_gateway/cli.py
+++ b/data_gateway/cli.py
@@ -234,13 +234,15 @@ def start(
     thread = threading.Thread(target=packet_reader.read_packets, args=(serial_port,), daemon=True)
     thread.start()
 
-    # Keep a record of the commands given.
-    commands_record_file = os.path.join(
-        packet_reader.output_directory, packet_reader.session_subdirectory, "commands.txt"
-    )
-
     try:
         if interactive:
+            # Keep a record of the commands given.
+            commands_record_file = os.path.join(
+                packet_reader.output_directory, packet_reader.session_subdirectory, "commands.txt"
+            )
+
+            os.makedirs(os.path.join(packet_reader.output_directory, packet_reader.session_subdirectory), exist_ok=True)
+
             while not packet_reader.stop:
                 for line in sys.stdin:
 

--- a/data_gateway/cli.py
+++ b/data_gateway/cli.py
@@ -357,6 +357,8 @@ def _get_serial_port(serial_port, configuration, use_dummy_serial_port):
             rx_size=configuration.serial_buffer_rx_size,
             tx_size=configuration.serial_buffer_tx_size,
         )
+    else:
+        logger.warning("Serial port buffer size can only be set on Windows.")
 
     return serial_port
 

--- a/data_gateway/cli.py
+++ b/data_gateway/cli.py
@@ -175,18 +175,19 @@ def start(
         config = Configuration()
         logger.info("No configuration file provided - using default configuration.")
 
-    if routine_file:
+    if os.path.exists(routine_file):
         if interactive:
             logger.warning("Sensor command routine files are ignored in interactive mode.")
-
         else:
-            if os.path.exists(routine_file):
-                with open(routine_file) as f:
-                    routine = Routine(**json.load(f), action=lambda command: serial_port.write(command.encode("utf_8")))
-                logger.info("Loaded routine file from %r.", routine_file)
-            else:
-                routine = None
-                logger.info("No routine provided - sensors only controlled by interactive user input.")
+            with open(routine_file) as f:
+                routine = Routine(**json.load(f), action=lambda command: serial_port.write(command.encode("utf_8")))
+            logger.info("Loaded routine file from %r.", routine_file)
+    else:
+        routine = None
+        logger.info(
+            "No routine file found at %r - no commands will be sent to the sensors unless given in interactive mode.",
+            routine_file,
+        )
 
     config.session_data["label"] = label
 

--- a/data_gateway/exceptions.py
+++ b/data_gateway/exceptions.py
@@ -14,3 +14,7 @@ class WrongNumberOfSensorCoordinatesError(GatewayError, ValueError):
     """Raise if the number of sensor coordinates given for a sensor does not equal the number of sensors specified in
     the `number_of_sensors` configuration field.
     """
+
+
+class DataMustBeSavedError(GatewayError, ValueError):
+    """Raise if options are given to the packet reader that mean no data will be saved locally or uploaded to the cloud."""

--- a/data_gateway/routine.py
+++ b/data_gateway/routine.py
@@ -21,7 +21,7 @@ class Routine:
 
     def __init__(self, commands, action, period=None, stop_after=None):
         self.commands = commands
-        self.action = action
+        self.action = self._wrap_action_with_logger(action)
         self.period = period
         self.stop_after = stop_after
 
@@ -63,3 +63,21 @@ class Routine:
             if self.stop_after:
                 if time.perf_counter() - start_time >= self.stop_after:
                     break
+
+    def _wrap_action_with_logger(self, action):
+        """Wrap the given action so that when it's run on a command, the command is logged.
+
+        :param callable action: action for handling command
+        :return callable: action with logging included
+        """
+
+        def action_with_logging(command):
+            """Run the action on the command and log that it was run.
+
+            :param str command:
+            :return None:
+            """
+            action(command)
+            logger.info("Routine ran %r command.", command)
+
+        return action_with_logging

--- a/data_gateway/routine.py
+++ b/data_gateway/routine.py
@@ -20,7 +20,7 @@ class Routine:
         self.stop_after = stop_after
 
         if self.period:
-            for command, delay in self.commands.items():
+            for command, delay in self.commands:
                 if delay > self.period:
                     raise ValueError("The delay for each command in the routine should be less than the period.")
 
@@ -35,7 +35,7 @@ class Routine:
         while True:
             cycle_start_time = time.perf_counter()
 
-            for command, delay in self.commands.items():
+            for command, delay in self.commands:
                 scheduler.enter(delay=delay, priority=1, action=self.action, argument=(command,))
 
             scheduler.run(blocking=True)

--- a/data_gateway/routine.py
+++ b/data_gateway/routine.py
@@ -1,0 +1,51 @@
+import sched
+import time
+
+
+class Routine:
+    """A routine of commands to give to the action after the given delays. A period can be given for repetition of the
+    set of commands, as well as a time to stop repeating after. If no period is given, the commands are run once.
+
+    :param list(dict(str, float)) commands: dictionaries with the command name as the key and the delay as the value
+    :param callable action: a function or method taking the command name as a single argument
+    :param float|None period: the time in seconds to repeat the set of commands
+    :param float|None stop_after: the time in seconds to stop repeating the set of commands
+    :return None:
+    """
+
+    def __init__(self, commands, action, period=None, stop_after=None):
+        self.commands = commands
+        self.action = action
+        self.period = period
+        self.stop_after = stop_after
+
+        if self.period:
+            for command, delay in self.commands.items():
+                if delay > self.period:
+                    raise ValueError("The delay for each command in the routine should be less than the period.")
+
+    def run(self):
+        """Send the commands to the action after the given delays, repeating if a period was given.
+
+        :return None:
+        """
+        scheduler = sched.scheduler(time.perf_counter)
+        start_time = time.perf_counter()
+
+        while True:
+            cycle_start_time = time.perf_counter()
+
+            for command, delay in self.commands.items():
+                scheduler.enter(delay=delay, priority=1, action=self.action, argument=(command,))
+
+            scheduler.run(blocking=True)
+
+            if self.period is None:
+                break
+
+            elapsed_time = time.perf_counter() - cycle_start_time
+            time.sleep(self.period - elapsed_time)
+
+            if self.stop_after:
+                if time.perf_counter() - start_time > self.stop_after:
+                    break

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,6 +40,7 @@ outages.
    installation
    using_the_gateway
    output_data
+   sensor_command_routines
    deployment
    cloud_functions
    cloud_preprocessing

--- a/docs/source/routines.rst
+++ b/docs/source/routines.rst
@@ -1,0 +1,45 @@
+.. _sensor_command_routines:
+
+=======================
+Sensor command routines
+=======================
+
+Commands can be sent to the sensors in two ways:
+
+- The user manually typing them in in interactive mode
+- Creating a routine JSON file and providing it to the CLI
+
+
+Creating and providing a routine file
+-------------------------------------
+
+A routine file looks like this:
+
+.. code-block::
+
+    {
+        "commands": [["startIMU", 0.1], ["startBaros", 0.2], ["getBattery", 3]]
+        "period": 5  # (period is optional)
+    }
+
+and can be provided to the CLI's ``start`` command by using:
+
+.. code-block::
+
+    --routine-file=<path/to/routine_file.json>
+
+If this option isn't provided, the CLI looks for a file called ``routine.json`` in the current working directory. If this file doesn't 
+exist and the ``--routine-file`` option isn't provided, the command assumes there is no routine file to run.
+
+.. warning::
+    If a routine file is provided in interactive mode, the routine is ignored. Only the commands entered interactively are sent to the
+    sensors.
+
+
+Routine file schema
+-------------------
+
+- The ``commands`` key in the file should be a list of two-element lists. Each two-element list should comprise a valid string command to 
+send to the sensors and a delay in seconds from the gateway starting to run the command.
+- An optional ``period`` in seconds can be provided to repeat the routine. If none is provided, the routine is run once only. 
+  The period must be greater than each of the commands' delays.

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,4 @@ force_grid_wrap=0
 combine_as_imports=True
 
 [pydocstyle]
-ignore = D100, D101, D104, D105, D107, D203, D205, D213, D400, D415
+ignore = D100, D101, D104, D105, D107, D203, D205, D213, D301, D400, D415

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("LICENSE") as f:
 
 setup(
     name="data_gateway",
-    version="0.7.6",
+    version="0.8.0",
     install_requires=[
         "click>=7.1.2",
         "pyserial==3.5",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,7 +101,7 @@ class TestStart(BaseTestCase):
                 with mock.patch("serial.Serial", new=DummySerial):
                     result = CliRunner().invoke(
                         gateway_cli,
-                        ["start", "--no-upload-to-cloud", f"--output-dir={temporary_directory}"],
+                        ["start", "--interactive", "--no-upload-to-cloud", f"--output-dir={temporary_directory}"],
                         input=commands,
                     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import tempfile
@@ -123,7 +124,7 @@ class TestStart(BaseTestCase):
                     json.dump({"commands": [["startIMU", 0.1], ["startBaros", 0.2], ["stop", 0.3]]}, f)
 
                 routine_commands = []
-                dummy_serial_class_with_dummy_write_method = DummySerial
+                dummy_serial_class_with_dummy_write_method = copy.deepcopy(DummySerial)
                 dummy_serial_class_with_dummy_write_method.write = routine_commands.append
 
                 with mock.patch("serial.Serial", new=DummySerial):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -187,8 +187,8 @@ class TestStart(BaseTestCase):
 
                 self.assertTrue(debug_message_found)
 
-    def test_start_and_stop_in_local_save_mode(self):
-        """Ensure the gateway can be started and stopped via the CLI in `--save-locally` mode."""
+    def test_start_and_stop_in_interactive_mode(self):
+        """Ensure the gateway can be started and stopped via the CLI in interactive mode."""
         with tempfile.TemporaryDirectory() as temporary_directory:
             with EnvironmentVariableRemover("GOOGLE_APPLICATION_CREDENTIALS"):
                 with mock.patch("logging.StreamHandler.emit") as mock_local_logger_emit:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,7 +155,7 @@ class TestStart(BaseTestCase):
                 self.assertIsNone(result.exception)
                 self.assertEqual(result.exit_code, 0)
 
-        self.assertEqual(mock_write.call_args_list, [call(b"startIMU"), call(b"startBaros"), call(b"stop")])
+        self.assertEqual(mock_write.call_args_list, [call(b"startIMU\n"), call(b"startBaros\n"), call(b"stop\n")])
 
     def test_log_level_can_be_set(self):
         """Test that the log level can be set."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,9 +51,7 @@ class TestCLI(BaseTestCase):
 
 class TestStart(BaseTestCase):
     def test_start(self):
-        """Ensure the gateway can be started via the CLI. The "stop-when-no-more-data" option is enabled so the test
-        doesn't run forever.
-        """
+        """Ensure the gateway can be started via the CLI."""
         with tempfile.TemporaryDirectory() as temporary_directory:
             with mock.patch("serial.Serial", new=DummySerial):
                 result = CliRunner().invoke(
@@ -63,17 +61,15 @@ class TestStart(BaseTestCase):
                         f"--gcp-project-name={TEST_PROJECT_NAME}",
                         f"--gcp-bucket-name={TEST_BUCKET_NAME}",
                         f"--output-dir={temporary_directory}",
-                        "--stop-when-no-more-data",
                     ],
+                    input="stop\n",
                 )
 
         self.assertIsNone(result.exception)
         self.assertEqual(result.exit_code, 0)
 
     def test_start_with_default_output_directory(self):
-        """Ensure the gateway can be started via the CLI with a default output directory. The "stop-when-no-more-data"
-        option is enabled so the test doesn't run forever.
-        """
+        """Ensure the gateway can be started via the CLI with a default output directory."""
         initial_directory = os.getcwd()
 
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -86,8 +82,8 @@ class TestStart(BaseTestCase):
                         "start",
                         f"--gcp-project-name={TEST_PROJECT_NAME}",
                         f"--gcp-bucket-name={TEST_BUCKET_NAME}",
-                        "--stop-when-no-more-data",
                     ],
+                    input="sleep 2\nstop\n",
                 )
 
             self.assertIsNone(result.exception)
@@ -105,7 +101,7 @@ class TestStart(BaseTestCase):
                 with mock.patch("serial.Serial", new=DummySerial):
                     result = CliRunner().invoke(
                         gateway_cli,
-                        ["start", "--interactive", f"--output-dir={temporary_directory}"],
+                        ["start", "--no-upload-to-cloud", f"--output-dir={temporary_directory}"],
                         input=commands,
                     )
 
@@ -125,7 +121,7 @@ class TestStart(BaseTestCase):
                         [
                             "--log-level=debug",
                             "start",
-                            "--interactive",
+                            "--no-upload-to-cloud",
                             f"--output-dir={temporary_directory}",
                         ],
                         input="stop\n",
@@ -153,7 +149,7 @@ class TestStart(BaseTestCase):
                     with mock.patch("serial.Serial", new=DummySerial):
                         result = CliRunner().invoke(
                             gateway_cli,
-                            ["start", "--interactive", f"--output-dir={temporary_directory}"],
+                            ["start", "--no-upload-to-cloud", f"--output-dir={temporary_directory}"],
                             input="stop\n",
                         )
 
@@ -178,7 +174,7 @@ class TestStart(BaseTestCase):
                 with mock.patch("serial.Serial", return_value=serial_port):
                     result = CliRunner().invoke(
                         gateway_cli,
-                        ["start", "--interactive", f"--output-dir={temporary_directory}"],
+                        ["start", "--no-upload-to-cloud", f"--output-dir={temporary_directory}"],
                         input="sleep 2\nstop\n",
                     )
 
@@ -206,7 +202,7 @@ class TestStart(BaseTestCase):
                             gateway_cli,
                             [
                                 "start",
-                                "--interactive",
+                                "--no-upload-to-cloud",
                                 f"--config-file={CONFIGURATION_PATH}",
                                 f"--output-dir={temporary_directory}",
                             ],

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -31,7 +31,7 @@ class TestRoutine(TestCase):
     def test_error_raised_if_stop_after_time_is_less_than_period(self):
         """Test that an error is raised if the `stop_after` time is less than the period."""
         with self.assertRaises(ValueError):
-            Routine(commands=[("first-command", 10), ("second-command", 0.3)], action=None, period=1, stop_after=0.5)
+            Routine(commands=[("first-command", 0.1), ("second-command", 0.3)], action=None, period=1, stop_after=0.5)
 
     def test_warning_raised_if_stop_after_time_provided_without_a_period(self):
         """Test that a warning is raised if the `stop_after` time is provided without a period."""

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -1,0 +1,58 @@
+import time
+from unittest import TestCase
+
+from data_gateway.routine import Routine
+
+
+class TestRoutine(TestCase):
+    def test_routine_with_no_period(self):
+        """Test that commands can be scheduled to run once when a period isn't given."""
+        recorded_commands = []
+
+        def record_commands(command):
+            recorded_commands.append((command, time.perf_counter()))
+
+        routine = Routine(commands={"first-command": 0.1, "second-command": 0.3}, action=record_commands)
+
+        start_time = time.perf_counter()
+        routine.run()
+
+        self.assertEqual(recorded_commands[0][0], "first-command")
+        self.assertAlmostEqual(recorded_commands[0][1], start_time + 0.1, places=1)
+
+        self.assertEqual(recorded_commands[1][0], "second-command")
+        self.assertAlmostEqual(recorded_commands[1][1], start_time + 0.3, places=1)
+
+    def test_error_raised_if_any_delay_is_greater_than_period(self):
+        """Test that an error is raised if any of the command delays is greater than the period."""
+        with self.assertRaises(ValueError):
+            Routine(commands={"first-command": 10, "second-command": 0.3}, action=None, period=1)
+
+    def test_routine_with_period(self):
+        """Test that commands can be scheduled to repeat at the given period."""
+        recorded_commands = []
+
+        def record_commands(command):
+            recorded_commands.append((command, time.perf_counter()))
+
+        routine = Routine(
+            commands={"first-command": 0.1, "second-command": 0.3},
+            action=record_commands,
+            period=0.4,
+            stop_after=1,
+        )
+
+        start_time = time.perf_counter()
+        routine.run()
+
+        self.assertEqual(recorded_commands[0][0], "first-command")
+        self.assertAlmostEqual(recorded_commands[0][1], start_time + 0.1, places=1)
+
+        self.assertEqual(recorded_commands[1][0], "second-command")
+        self.assertAlmostEqual(recorded_commands[1][1], start_time + 0.3, places=1)
+
+        self.assertEqual(recorded_commands[2][0], "first-command")
+        self.assertAlmostEqual(recorded_commands[2][1], start_time + 0.1 + routine.period, places=1)
+
+        self.assertEqual(recorded_commands[3][0], "second-command")
+        self.assertAlmostEqual(recorded_commands[3][1], start_time + 0.3 + routine.period, places=1)

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -12,7 +12,7 @@ class TestRoutine(TestCase):
         def record_commands(command):
             recorded_commands.append((command, time.perf_counter()))
 
-        routine = Routine(commands={"first-command": 0.1, "second-command": 0.3}, action=record_commands)
+        routine = Routine(commands=[("first-command", 0.1), ("second-command", 0.3)], action=record_commands)
 
         start_time = time.perf_counter()
         routine.run()
@@ -26,7 +26,7 @@ class TestRoutine(TestCase):
     def test_error_raised_if_any_delay_is_greater_than_period(self):
         """Test that an error is raised if any of the command delays is greater than the period."""
         with self.assertRaises(ValueError):
-            Routine(commands={"first-command": 10, "second-command": 0.3}, action=None, period=1)
+            Routine(commands=[("first-command", 10), ("second-command", 0.3)], action=None, period=1)
 
     def test_routine_with_period(self):
         """Test that commands can be scheduled to repeat at the given period."""
@@ -36,7 +36,7 @@ class TestRoutine(TestCase):
             recorded_commands.append((command, time.perf_counter()))
 
         routine = Routine(
-            commands={"first-command": 0.1, "second-command": 0.3},
+            commands=[("first-command", 0.1), ("second-command", 0.3)],
             action=record_commands,
             period=0.4,
             stop_after=1,

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -28,6 +28,21 @@ class TestRoutine(TestCase):
         with self.assertRaises(ValueError):
             Routine(commands=[("first-command", 10), ("second-command", 0.3)], action=None, period=1)
 
+    def test_error_raised_if_stop_after_time_is_less_than_period(self):
+        """Test that an error is raised if the `stop_after` time is less than the period."""
+        with self.assertRaises(ValueError):
+            Routine(commands=[("first-command", 10), ("second-command", 0.3)], action=None, period=1, stop_after=0.5)
+
+    def test_warning_raised_if_stop_after_time_provided_without_a_period(self):
+        """Test that a warning is raised if the `stop_after` time is provided without a period."""
+        with self.assertLogs() as logs_context:
+            Routine(commands=[("first-command", 10), ("second-command", 0.3)], action=None, stop_after=0.5)
+
+        self.assertEqual(
+            logs_context.output[0],
+            "WARNING:data_gateway.routine:The `stop_after` parameter is ignored unless `period` is also given.",
+        )
+
     def test_routine_with_period(self):
         """Test that commands can be scheduled to repeat at the given period."""
         recorded_commands = []

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -18,10 +18,10 @@ class TestRoutine(TestCase):
         routine.run()
 
         self.assertEqual(recorded_commands[0][0], "first-command")
-        self.assertAlmostEqual(recorded_commands[0][1], start_time + 0.1, places=1)
+        self.assertAlmostEqual(recorded_commands[0][1], start_time + 0.1, delta=0.1)
 
         self.assertEqual(recorded_commands[1][0], "second-command")
-        self.assertAlmostEqual(recorded_commands[1][1], start_time + 0.3, places=1)
+        self.assertAlmostEqual(recorded_commands[1][1], start_time + 0.3, delta=0.1)
 
     def test_error_raised_if_any_delay_is_greater_than_period(self):
         """Test that an error is raised if any of the command delays is greater than the period."""
@@ -46,13 +46,13 @@ class TestRoutine(TestCase):
         routine.run()
 
         self.assertEqual(recorded_commands[0][0], "first-command")
-        self.assertAlmostEqual(recorded_commands[0][1], start_time + 0.1, places=1)
+        self.assertAlmostEqual(recorded_commands[0][1], start_time + 0.1, delta=0.1)
 
         self.assertEqual(recorded_commands[1][0], "second-command")
-        self.assertAlmostEqual(recorded_commands[1][1], start_time + 0.3, places=1)
+        self.assertAlmostEqual(recorded_commands[1][1], start_time + 0.3, delta=0.1)
 
         self.assertEqual(recorded_commands[2][0], "first-command")
-        self.assertAlmostEqual(recorded_commands[2][1], start_time + 0.1 + routine.period, places=1)
+        self.assertAlmostEqual(recorded_commands[2][1], start_time + 0.1 + routine.period, delta=0.1)
 
         self.assertEqual(recorded_commands[3][0], "second-command")
-        self.assertAlmostEqual(recorded_commands[3][1], start_time + 0.3 + routine.period, places=1)
+        self.assertAlmostEqual(recorded_commands[3][1], start_time + 0.3 + routine.period, delta=0.1)

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -5,7 +5,7 @@ from data_gateway.routine import Routine
 
 
 class TestRoutine(TestCase):
-    def test_routine_with_no_period(self):
+    def test_routine_with_no_period_runs_commands_once(self):
         """Test that commands can be scheduled to run once when a period isn't given."""
         recorded_commands = []
 
@@ -18,10 +18,10 @@ class TestRoutine(TestCase):
         routine.run()
 
         self.assertEqual(recorded_commands[0][0], "first-command")
-        self.assertAlmostEqual(recorded_commands[0][1], start_time + 0.1, delta=0.1)
+        self.assertAlmostEqual(recorded_commands[0][1], start_time + 0.1, delta=0.2)
 
         self.assertEqual(recorded_commands[1][0], "second-command")
-        self.assertAlmostEqual(recorded_commands[1][1], start_time + 0.3, delta=0.1)
+        self.assertAlmostEqual(recorded_commands[1][1], start_time + 0.3, delta=0.2)
 
     def test_error_raised_if_any_delay_is_greater_than_period(self):
         """Test that an error is raised if any of the command delays is greater than the period."""
@@ -44,7 +44,7 @@ class TestRoutine(TestCase):
         )
 
     def test_routine_with_period(self):
-        """Test that commands can be scheduled to repeat at the given period."""
+        """Test that commands can be scheduled to repeat at the given period and then stop after a certain time."""
         recorded_commands = []
 
         def record_commands(command):
@@ -61,13 +61,13 @@ class TestRoutine(TestCase):
         routine.run()
 
         self.assertEqual(recorded_commands[0][0], "first-command")
-        self.assertAlmostEqual(recorded_commands[0][1], start_time + 0.1, delta=0.1)
+        self.assertAlmostEqual(recorded_commands[0][1], start_time + 0.1, delta=0.2)
 
         self.assertEqual(recorded_commands[1][0], "second-command")
-        self.assertAlmostEqual(recorded_commands[1][1], start_time + 0.3, delta=0.1)
+        self.assertAlmostEqual(recorded_commands[1][1], start_time + 0.3, delta=0.2)
 
         self.assertEqual(recorded_commands[2][0], "first-command")
-        self.assertAlmostEqual(recorded_commands[2][1], start_time + 0.1 + routine.period, delta=0.1)
+        self.assertAlmostEqual(recorded_commands[2][1], start_time + 0.1 + routine.period, delta=0.2)
 
         self.assertEqual(recorded_commands[3][0], "second-command")
-        self.assertAlmostEqual(recorded_commands[3][1], start_time + 0.3 + routine.period, delta=0.1)
+        self.assertAlmostEqual(recorded_commands[3][1], start_time + 0.3 + routine.period, delta=0.2)


### PR DESCRIPTION
## Summary
Add the ability to provide routines of sensor commands to run once or periodically. A routine can provided via a JSON file to the CLI via the new `--routine-file` option in the `start` command.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#12](https://github.com/aerosense-ai/data-gateway/pull/12))
**IMPORTANT:** There is 1 breaking change.

### New features
- Allow user to provide a routine of sensor commands to the CLI via a JSON routine file

### Enhancements
- **BREAKING CHANGE:** Separate interactive mode from whether data is saved locally or to the cloud
- Add CLI option to save data locally
- Add CLI option to not upload data to the cloud (i.e. uploading to the cloud is the default)
- Add `Routine` class for scheduling commands once or periodically
- Warn if serial port buffer size cannot be set due to not being on Windows

### Fixes
- Ensure commands file is always written to disk locally

### Refactoring
- Always run the packet reader in a separate thread so that commands can be sent to the serial port either in interactive mode or by a routine
- Factor out logic in CLI `start` command into functions
- Remove unused `--stop-when-no-more-data` option from CLI

### Testing
- Use `--use-dummy-serial-port` CLI option instead of mocking serial port in CLI tests

<!--- END AUTOGENERATED NOTES --->

## Quality Checklist
- [x] New features are fully tested (No matter how much Coverage Karma you have)
- [x] **[v0.2 onward]** New features are included in the documentation