### PR TITLE
Use separate thread to read packets from serial port

### DIFF
--- a/data_gateway/dummy_serial/dummy_serial.py
+++ b/data_gateway/dummy_serial/dummy_serial.py
@@ -72,6 +72,23 @@ class DummySerial(object):
         self._isOpen = True
         self.port = self.initial_port_name
 
+    @property
+    def is_open(self):
+        """Check if the serial port is open.
+
+        :return bool:
+        """
+        return self._isOpen
+
+    @is_open.setter
+    def is_open(self, value):
+        """Open or close the serial port.
+
+        :param bool value:
+        :return None:
+        """
+        self._isOpen = value
+
     def close(self):
         """Close the dummy serial port."""
         logger.debug("Closing port")

--- a/data_gateway/dummy_serial/dummy_serial.py
+++ b/data_gateway/dummy_serial/dummy_serial.py
@@ -80,15 +80,6 @@ class DummySerial(object):
         """
         return self._isOpen
 
-    @is_open.setter
-    def is_open(self, value):
-        """Open or close the serial port.
-
-        :param bool value:
-        :return None:
-        """
-        self._isOpen = value
-
     def close(self):
         """Close the dummy serial port."""
         logger.debug("Closing port")

--- a/data_gateway/packet_reader.py
+++ b/data_gateway/packet_reader.py
@@ -89,16 +89,14 @@ class PacketReader:
         serial_port_protocol = Protocol
         serial_port_protocol.configuration = self.config
         serial_port_protocol.packet_reader = self
+        serial_port_protocol.serial_port = serial_port
+        serial_port_protocol.stop_when_no_more_data = stop_when_no_more_data
         serial_port_protocol.initiator = self.config.packet_key.to_bytes(1, self.config.endian)
 
         with self.uploader:
             with self.writer:
                 while not self.stop:
-                    CustomReaderThread(
-                        serial_port,
-                        protocol_factory=serial_port_protocol,
-                        stop_when_no_more_data=stop_when_no_more_data,
-                    ).run()
+                    CustomReaderThread(serial_port, protocol_factory=serial_port_protocol).run()
 
     def update_handles(self, payload):
         """Update the Bluetooth handles object. Handles are updated every time a new Bluetooth connection is

--- a/data_gateway/packet_reader.py
+++ b/data_gateway/packet_reader.py
@@ -5,11 +5,12 @@ import os
 import struct
 
 from octue.cloud import storage
+from serial.threaded import ReaderThread
 
 from data_gateway import MICROPHONE_SENSOR_NAME, exceptions
 from data_gateway.configuration import Configuration
 from data_gateway.persistence import BatchingFileWriter, BatchingUploader, NoOperationContextManager
-from data_gateway.serial_protocol import CustomReaderThread, Protocol
+from data_gateway.serial_protocol import Protocol
 
 
 logger = logging.getLogger(__name__)
@@ -96,7 +97,7 @@ class PacketReader:
         with self.uploader:
             with self.writer:
                 while not self.stop:
-                    CustomReaderThread(serial_port, protocol_factory=serial_port_protocol).run()
+                    ReaderThread(serial_port, protocol_factory=serial_port_protocol).run()
 
     def update_handles(self, payload):
         """Update the Bluetooth handles object. Handles are updated every time a new Bluetooth connection is

--- a/data_gateway/serial_protocol.py
+++ b/data_gateway/serial_protocol.py
@@ -1,0 +1,145 @@
+import serial.threaded
+
+
+class Protocol(serial.threaded.Protocol):
+    configuration = None
+    packet_reader = None
+    initiator = b"\0"
+
+    def __init__(self):
+        self.transport = None
+        self.current_packet = bytearray()
+        self.current_packet_type = None
+        self.current_packet_expected_length = None
+        self._currently_receiving_packet = False
+
+        self.previous_timestamp = {}
+        self.collected_data = {}
+
+        for sensor_name in self.configuration.sensor_names:
+            self.previous_timestamp[sensor_name] = -1
+            self.collected_data[sensor_name] = [
+                ([0] * self.configuration.samples_per_packet[sensor_name])
+                for _ in range(self.configuration.number_of_sensors[sensor_name])
+            ]
+
+    def connection_made(self, transport):
+        self.transport = transport
+
+    def connection_lost(self, exc):
+        self.transport = None
+        super().connection_lost(exc)
+
+    def data_received(self, data):
+        """Assemble data into packets and handle them.
+
+        :param bytes data:
+        :return None:
+        """
+        # Ignore empty data.
+        if len(data) == 0:
+            return
+
+        # Start collecting a packet if the initiator byte is received.
+        if data == self.initiator:
+            self._currently_receiving_packet = True
+            return
+
+        # Ignore data if not currently receiving a packet.
+        if not self._currently_receiving_packet:
+            return
+
+        # Receive further bytes for the current packet.
+        if self.current_packet_type is None:
+            self.current_packet_type = str(int.from_bytes(data, self.configuration.endian))
+
+        elif self.current_packet_expected_length is None:
+            self.current_packet_expected_length = int.from_bytes(data, self.configuration.endian)
+
+        # Collect more data until the expected packet length is reached.
+        elif len(self.current_packet) < self.current_packet_expected_length:
+            self.current_packet.extend(data)
+
+        # When the expected packet length is reached, handle the packet and get ready for the next one.
+        else:
+            self.handle_packet(self.current_packet)
+            self._get_ready_for_new_packet()
+
+    def handle_packet(self, packet):
+        """Handle a packet by either updating the handles or parsing it as a payload for the packet reader.
+
+        :param bytes packet:
+        :return None:
+        """
+        if self.current_packet_type == str(self.configuration.type_handle_def):
+            self.packet_reader.update_handles(packet)
+            return
+
+        self.packet_reader._parse_payload(
+            packet_type=self.current_packet_type,
+            payload=packet,
+            data=self.collected_data,
+            previous_timestamp=self.previous_timestamp,
+        )
+
+    def _get_ready_for_new_packet(self):
+        """Reset the current packet information.
+
+        :return None:
+        """
+        self.current_packet = bytearray()
+        self.current_packet_type = None
+        self.current_packet_expected_length = None
+        self._currently_receiving_packet = False
+
+
+class CustomReaderThread(serial.threaded.ReaderThread):
+    def __init__(self, serial_instance, protocol_factory, stop_when_no_more_data=False):
+        self.stop_when_no_more_data = stop_when_no_more_data
+        super().__init__(serial_instance, protocol_factory)
+
+    def run(self):
+        """Reader loop"""
+        if not hasattr(self.serial, "cancel_read"):
+            self.serial.timeout = 1
+
+        self.protocol = self.protocol_factory()
+
+        try:
+            self.protocol.connection_made(self)
+
+        except Exception as e:
+            self.alive = False
+            self.protocol.connection_lost(e)
+            self._connection_made.set()
+            return
+
+        error = None
+        self._connection_made.set()
+
+        while self.alive and self.serial.is_open:
+            try:
+                # read all that is there or wait for one byte (blocking)
+                data = self.serial.read(1)
+            except serial.SerialException as e:
+                # probably some I/O problem such as disconnected USB serial
+                # adapters -> exit
+                error = e
+                break
+            else:
+                if data:
+                    # make a separated try-except for called user code
+                    try:
+                        self.protocol.data_received(data)
+                    except Exception as e:
+                        error = e
+                        break
+
+                else:
+                    if self.stop_when_no_more_data:
+                        self.serial.is_open = False
+                        self.protocol.packet_reader.stop = True
+
+        self.alive = False
+        self.protocol.connection_lost(error)
+        self.protocol = None

--- a/data_gateway/serial_protocol.py
+++ b/data_gateway/serial_protocol.py
@@ -1,11 +1,19 @@
 import serial.threaded
 
 
-class Protocol(serial.threaded.Protocol):
-    configuration = None
-    packet_reader = None
-    serial_port = None
-    stop_when_no_more_data = False
+class SerialPortReadingProtocol(serial.threaded.Protocol):
+    """A threaded protocol for reading data from a serial port and assembling it into packets for the packet reader to
+    parse. Serial port reading is carried out in a separate thread to packet handling, reducing the likelihood of data
+    loss due to a serial port buffer overflow. Packets are assumed to take on the following format with any amount of
+    non-packet noise in between:
+
+    ```
+    <Packet key><Packet type><Packet length><First byte of packet data>...<nth byte of packet data>
+    ```
+
+    :return None:
+    """
+
     initiator = b"\0"
 
     def __init__(self):
@@ -20,27 +28,40 @@ class Protocol(serial.threaded.Protocol):
         self.previous_timestamp = {}
         self.collected_data = {}
 
-        for sensor_name in self.configuration.sensor_names:
-            self.previous_timestamp[sensor_name] = -1
-            self.collected_data[sensor_name] = [
-                ([0] * self.configuration.samples_per_packet[sensor_name])
-                for _ in range(self.configuration.number_of_sensors[sensor_name])
-            ]
-
     def connection_made(self, transport):
+        """Set the transport attribute to the reader thread when it is started, update the previous timestamp and
+        collected data parameters, and set the packet initiator to the packet key from the packet reader configuration.
+
+        :param CustomReaderThread transport:
+        :return None:
+        """
         self.transport = transport
 
-    def connection_lost(self, exc):
+        for sensor_name in transport.packet_reader.config.sensor_names:
+            self.previous_timestamp[sensor_name] = -1
+            self.collected_data[sensor_name] = [
+                ([0] * transport.packet_reader.config.samples_per_packet[sensor_name])
+                for _ in range(transport.packet_reader.config.number_of_sensors[sensor_name])
+            ]
+
+        self.initiator = transport.packet_reader.config.packet_key.to_bytes(1, transport.packet_reader.config.endian)
+
+    def connection_lost(self, exception):
+        """Forget the reader thread.
+
+        :param Exception exception:
+        :return None:
+        """
         self.transport = None
-        super().connection_lost(exc)
+        super().connection_lost(exception)
 
     def data_received(self, data):
-        """Assemble data into packets and handle them.
+        """Pull all waiting data from the serial port into an in-memory buffer, assemble it into packets, and handle
+        the packets.
 
         :param bytes data:
         :return None:
         """
-        # Ignore empty data.
         if len(data) == 0:
             return
 
@@ -61,12 +82,12 @@ class Protocol(serial.threaded.Protocol):
 
             # Receive further bytes for the current packet.
             if self.current_packet_type is None:
-                self.current_packet_type = str(int.from_bytes(byte, self.configuration.endian))
+                self.current_packet_type = str(int.from_bytes(byte, self.transport.packet_reader.config.endian))
                 continue
 
             # Get the expected length of the packet.
             if self.current_packet_expected_length is None:
-                self.current_packet_expected_length = int.from_bytes(byte, self.configuration.endian)
+                self.current_packet_expected_length = int.from_bytes(byte, self.transport.packet_reader.config.endian)
                 continue
 
             # Collect more data until the expected packet length is reached.
@@ -78,20 +99,20 @@ class Protocol(serial.threaded.Protocol):
                 self.handle_packet()
                 self._prepare_for_new_packet()
 
-            if self.stop_when_no_more_data and self.serial_port.in_waiting == 0:
-                self.serial_port.close()
-                self.packet_reader.stop = True
+            if self.transport.stop_when_no_more_data and self.transport.serial.in_waiting == 0:
+                self.transport.serial.close()
+                self.transport.packet_reader.stop = True
 
     def handle_packet(self):
         """Handle a packet by either updating the handles or parsing it as a payload for the packet reader.
 
         :return None:
         """
-        if self.current_packet_type == str(self.configuration.type_handle_def):
-            self.packet_reader.update_handles(self.current_packet)
+        if self.current_packet_type == str(self.transport.packet_reader.config.type_handle_def):
+            self.transport.packet_reader.update_handles(self.current_packet)
             return
 
-        self.packet_reader._parse_payload(
+        self.transport.packet_reader.parse_payload(
             packet_type=self.current_packet_type,
             payload=self.current_packet,
             data=self.collected_data,
@@ -107,3 +128,19 @@ class Protocol(serial.threaded.Protocol):
         self.current_packet_type = None
         self.current_packet_expected_length = None
         self._currently_receiving_packet = False
+
+
+class CustomReaderThread(serial.threaded.ReaderThread):
+    """A custom thread-based serial port reader for the data gateway.
+
+    :param serial.Serial serial_instance: the serial port to read from
+    :param type protocol_factory: this should be the `SerialPortReadingProtocol` class (not an instance of it)
+    :param data_gateway.packet_reader.PacketReader packet_reader: an instance of the data gateway packet reader
+    :param bool stop_when_no_more_data: stop reading when no more data is received from the port (for testing)
+    :return None:
+    """
+
+    def __init__(self, serial_instance, protocol_factory, packet_reader, stop_when_no_more_data=False):
+        self.packet_reader = packet_reader
+        self.stop_when_no_more_data = stop_when_no_more_data
+        super().__init__(serial_instance, protocol_factory)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("LICENSE") as f:
 
 setup(
     name="data_gateway",
-    version="0.7.6",
+    version="0.7.7",
     install_requires=[
         "click>=7.1.2",
         "pyserial==3.5",

--- a/tests/test_packet_reader.py
+++ b/tests/test_packet_reader.py
@@ -418,18 +418,25 @@ class TestPacketReader(BaseTestCase):
         """Test that the packet reader works with info packets."""
         serial_port = DummySerial(port="test")
 
-        packet_types = [bytes([40]), bytes([54]), bytes([56]), bytes([58])]
+        packet_types = {
+            "Mic 1": bytes([40]),
+            "Cmd Decline": bytes([54]),
+            "Sleep State": bytes([56]),
+            "Info Message": bytes([58]),
+        }
 
-        payloads = [
-            [bytes([1]), bytes([2]), bytes([3])],
-            [bytes([0]), bytes([1]), bytes([2]), bytes([3])],
-            [bytes([0]), bytes([1])],
-            [bytes([0] * 13)],
-        ]
+        payloads = {
+            "Mic 1": [bytes([1]), bytes([2]), bytes([3])],
+            "Cmd Decline": [bytes([0]), bytes([1]), bytes([2]), bytes([3])],
+            "Sleep State": [bytes([0]), bytes([1])],
+            "Info Message": [bytes([0] * 13)],
+        }
 
-        for index, packet_type in enumerate(packet_types):
-            for payload in payloads[index]:
-                serial_port.write(data=b"".join((PACKET_KEY, packet_type, bytes([len(payload)]), payload)))
+        for packet_type, packet_key in packet_types.items():
+            for payload in payloads[packet_type]:
+
+                packet_length = bytes([len(payload)])
+                serial_port.write(data=b"".join([PACKET_KEY, packet_key, packet_length, payload]))
 
         with tempfile.TemporaryDirectory() as temporary_directory:
             packet_reader = PacketReader(
@@ -441,6 +448,16 @@ class TestPacketReader(BaseTestCase):
                 bucket_name=TEST_BUCKET_NAME,
             )
 
-            with patch("data_gateway.packet_reader.logger") as mock_logger:
+            with self.assertLogs() as logging_context:
                 packet_reader.read_packets(serial_port, stop_when_no_more_data=True)
-                self.assertEqual(11, len(mock_logger.method_calls))
+
+            self.assertIn("Microphone data reading done", logging_context.output[0])
+            self.assertIn("Microphone data erasing done", logging_context.output[1])
+            self.assertIn("Microphones started", logging_context.output[2])
+            self.assertIn("Command declined, Bad block detection ongoing", logging_context.output[3])
+            self.assertIn("Command declined, Task already registered, cannot register again", logging_context.output[4])
+            self.assertIn("Command declined, Task is not registered, cannot de-register", logging_context.output[5])
+            self.assertIn("Command declined, Connection Parameter update unfinished", logging_context.output[6])
+            self.assertIn("Exiting sleep", logging_context.output[7])
+            self.assertIn("Entering sleep", logging_context.output[8])
+            self.assertIn("Battery info", logging_context.output[9])


### PR DESCRIPTION
## Summary
Separate serial port reading from packet parsing, processing, and persistence to avoid data loss due to serial port overflow.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#15](https://github.com/aerosense-ai/data-gateway/pull/15))

### Enhancements
- Use `serial.threading` to bulk read packets from serial port in a separate thread

### Refactoring
- Rename `PacketReader._parse_payload` to `PacketReader.parse_payload`

### Testing
- Improve information packets test

<!--- END AUTOGENERATED NOTES --->