### PR TITLE
Ensure sensor commands always end in a newline

### DIFF
--- a/data_gateway/data_gateway.py
+++ b/data_gateway/data_gateway.py
@@ -2,6 +2,7 @@ import json
 import logging
 import multiprocessing
 import os
+import re
 import sys
 import threading
 import time
@@ -276,7 +277,7 @@ class DataGateway:
                     line = line.strip()
 
                     # The `sleep` command is mainly for facilitating testing.
-                    if line.startswith("sleep"):
+                    if re.match(r"sleep\s\d+", line):
                         time.sleep(int(line.split(" ")[-1].strip()))
                         continue
 

--- a/data_gateway/data_gateway.py
+++ b/data_gateway/data_gateway.py
@@ -182,7 +182,7 @@ class DataGateway:
 
             # This should ensure that the `stopMics` command is run last.
             for command in sensor_stop_commands:
-                self.serial_port.write(command.encode("utf_8"))
+                self._send_command_to_sensors(command)
                 logger.info("Sent %r command.", command)
                 time.sleep(5)
 
@@ -243,10 +243,7 @@ class DataGateway:
                 return
 
             with open(routine_path) as f:
-                routine = Routine(
-                    **json.load(f),
-                    action=lambda command: self.serial_port.write((command + "\n").encode("utf_8")),
-                )
+                routine = Routine(**json.load(f), action=self._send_command_to_sensors)
 
             logger.info("Loaded routine file from %r.", routine_path)
             return routine
@@ -256,6 +253,10 @@ class DataGateway:
                 "No routine was provided and interactive mode is off - no commands will be sent to the sensors in this "
                 "session."
             )
+
+    def _send_command_to_sensors(self, command):
+        self.serial_port.write((command + "\n").encode("utf_8"))
+        logger.info("Sent %r command to sensors.", command)
 
     def _send_commands_from_stdin_to_sensors(self, stop_signal):
         """Send commands from `stdin` to the sensors until the "stop" command is received or the packet reader is
@@ -272,18 +273,18 @@ class DataGateway:
                     with open(commands_record_file, "a") as f:
                         f.write(line)
 
+                    line = line.strip()
+
                     # The `sleep` command is mainly for facilitating testing.
-                    if line.startswith("sleep") and line.endswith("\n"):
+                    if line.startswith("sleep"):
                         time.sleep(int(line.split(" ")[-1].strip()))
                         continue
 
-                    if line == "stop\n":
-                        self.serial_port.write(line.encode("utf_8"))
+                    self._send_command_to_sensors(line)
+
+                    if line == "stop":
                         stop_gateway(logger, stop_signal)
                         break
-
-                    # Send the command to the node.
-                    self.serial_port.write(line.encode("utf_8"))
 
         except Exception as e:
             stop_gateway(logger, stop_signal)

--- a/data_gateway/data_gateway.py
+++ b/data_gateway/data_gateway.py
@@ -256,6 +256,11 @@ class DataGateway:
             )
 
     def _send_command_to_sensors(self, command):
+        """Send a textual command to the sensors.
+
+        :param str command: the command to send
+        :return None:
+        """
         self.serial_port.write((command + "\n").encode("utf_8"))
         logger.info("Sent %r command to sensors.", command)
 

--- a/data_gateway/routine.py
+++ b/data_gateway/routine.py
@@ -23,7 +23,7 @@ class Routine:
 
     def __init__(self, commands, action, period=None, stop_after=None):
         self.commands = commands
-        self.action = self._wrap_action_with_logger(action)
+        self.action = action
         self.period = period
         self.stop_after = stop_after
 
@@ -80,21 +80,3 @@ class Routine:
         except Exception as e:
             stop_gateway(logger, stop_signal)
             raise e
-
-    def _wrap_action_with_logger(self, action):
-        """Wrap the given action so that when it's run on a command, the command is logged.
-
-        :param callable action: action for handling command
-        :return callable: action with logging included
-        """
-
-        def action_with_logging(command):
-            """Run the action on the command and log that it was run.
-
-            :param str command:
-            :return None:
-            """
-            action(command)
-            logger.info("Routine ran %r command.", command)
-
-        return action_with_logging

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("LICENSE") as f:
 
 setup(
     name="data_gateway",
-    version="0.11.3",
+    version="0.11.4",
     install_requires=[
         "click>=7.1.2",
         "pyserial==3.5",


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#44](https://github.com/aerosense-ai/data-gateway/pull/44))

### Enhancements
- Make parsing of non-sensor `sleep` command more robust

### Fixes
- Ensure sensor commands always end in a newline

<!--- END AUTOGENERATED NOTES --->