### PR TITLE
Fix balena deployment on devops

### DIFF
--- a/.github/workflows/balena.yml
+++ b/.github/workflows/balena.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: theaccordance/balena-push@v1.0.0
         with:
           api-token: ${{secrets.BALENA_API_TOKEN}}
-          application-name: ${{secrets.BALENA_APPLICATION_NAME}}
+          application-name: gateways

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-gateway"
-version = "0.13.3"
+version = "0.13.4"
 repository = "https://github.com/aerosense-ai/data-gateway"
 description = "A data gateway that runs on-nacelle for relaying data streams from aerosense nodes to cloud."
 readme = "README.md"


### PR DESCRIPTION
# Summary

Makes the main branch deploy automatically to the gateways fleet via balena

<!--- START AUTOGENERATED NOTES --->
# Contents ([#93](https://github.com/aerosense-ai/data-gateway/pull/93))

### Operations
- Make balena deploy from main branch
- Update version patch for balena deployment fix

<!--- END AUTOGENERATED NOTES --->